### PR TITLE
add schema_name in configuration

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -128,6 +128,8 @@ class Configuration implements ConfigurationInterface
                     ->scalarNode('server_selection')
                         ->info('Determines how the LDAP server is selected. Can be "order" or "random".')->end()
                     ->scalarNode('encoding')->end()
+                    ->scalarNode('schema_name')
+                        ->info('The schema name to use for this domain')->end()
                     ->scalarNode('bind_format')
                         ->info('Set to a string that determines where the username is placed in a bind attempt: %%username%%,ou=users,dc=foo,dc=bar')->end()
                     ->arrayNode('ldap_options')


### PR DESCRIPTION
hi,

i've to add it to use my own schema

to use it
add it to symfony2-3 config.yml file :
<pre>
ldap_tools:
    general:
        schema_folder: "%kernel.root_dir%/Resources/schema"
    domains:
        myDomain:
            domain_name: myDomain.com
            username: cn=manager,o=mydomain,c=com
            password: change_it
            base_dn: "o= mydomain,c=com"
            servers: ["ldap.mydomain.com"]
            ldap_type: "openldap"
            schema_name: "mydomain"
</pre>

could you accept this pull request ?
