### PR TITLE
Allow remember when authenticated through Ldap

### DIFF
--- a/Security/LdapGuardAuthenticator.php
+++ b/Security/LdapGuardAuthenticator.php
@@ -244,7 +244,7 @@ class LdapGuardAuthenticator extends AbstractGuardAuthenticator
      */
     public function supportsRememberMe()
     {
-        return false;
+        return true;
     }
 
     /**


### PR DESCRIPTION
As discussed in #14, `remember me` can be allowed as every required check is performed before authentication is granted (because only credentials are kept).

For example, I disabled a user account and tried to come back and I got a:

```
The token storage was not populated with remember-me token as the AuthenticationManager rejected the AuthenticationToken returned by the RememberMeServices.
```

(which redirected me to the login form).

The remember me functionnality can be configured following the official Symfony documentation.