### PR TITLE
Fixed config error in doc

### DIFF
--- a/Resources/doc/LDAP-Authentication-Provider.md
+++ b/Resources/doc/LDAP-Authentication-Provider.md
@@ -253,7 +253,7 @@ ldap_tools:
     security:
         guard:
             # This is the entry point/start path route name for the RedirectResponse of the Guard component
-            start_path: 'login'
+            login_path: 'login'
             default_target_path: '/'
             always_use_target_path: false
             target_path_parameter: '_target_path'


### PR DESCRIPTION
Hey,

the doc file states the entry point is `start_path`, but the correct name is `login_path`.

Cheers
Matthias