### PR TITLE
Persist roles to avoid 403 errors

### DIFF
--- a/Resources/doc/Save-LDAP-Users-to-the-Database-After-Login.md
+++ b/Resources/doc/Save-LDAP-Users-to-the-Database-After-Login.md
@@ -52,6 +52,7 @@ class AppUser implements LdapUserInterface, UserInterface
 
     /**
      * @var array
+     * @ORM\Column(type="array")
      */
     private $roles = [];
     


### PR DESCRIPTION
If you don't persist roles, every login after the 1st one will have empty roles property and so all protected pages will return 403 error.