### PR TITLE
Change the option use_referrer to use_referer

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -215,7 +215,7 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('default_target_path')->defaultValue('/')->end()
                             ->booleanNode('always_use_target_path')->defaultFalse()->end()
                             ->scalarNode('target_path_parameter')->defaultValue('_target_path')->end()
-                            ->booleanNode('use_referrer')->defaultFalse()->end()
+                            ->booleanNode('use_referer')->defaultFalse()->end()
                             ->scalarNode('failure_path')->defaultNull()->end()
                             ->booleanNode('failure_forward')->defaultFalse()->end()
                             ->scalarNode('failure_path_parameter')->defaultValue('_failure_path')->end()

--- a/DependencyInjection/LdapToolsExtension.php
+++ b/DependencyInjection/LdapToolsExtension.php
@@ -136,7 +136,7 @@ class LdapToolsExtension extends Extension
             'default_target_path' => $config['default_target_path'],
             'always_use_target_path' => $config['always_use_target_path'],
             'target_path_parameter' => $config['target_path_parameter'],
-            'use_referrer' => $config['use_referrer'],
+            'use_referer' => $config['use_referer'],
             'login_path' => $config['login_path'],
         ]);
         $container->setParameter('ldap_tools.security.guard.auth_failure', [

--- a/Resources/doc/Configuration-Reference.md
+++ b/Resources/doc/Configuration-Reference.md
@@ -246,7 +246,7 @@ Refer to: http://symfony.com/doc/current/reference/configuration/security.html#r
 **Default**: `_target_path`
 
  ------------------
-#### use_referrer
+#### use_referer
 
 Refer to: http://symfony.com/doc/current/reference/configuration/security.html#redirecting-after-login
 

--- a/Resources/doc/LDAP-Authentication-Provider.md
+++ b/Resources/doc/LDAP-Authentication-Provider.md
@@ -257,7 +257,7 @@ ldap_tools:
             default_target_path: '/'
             always_use_target_path: false
             target_path_parameter: '_target_path'
-            use_referrer: false
+            use_referer: false
             failure_path: null
             failure_forward: false
             failure_path_parameter: '_failure_path'

--- a/spec/LdapTools/Bundle/LdapToolsBundle/DependencyInjection/LdapToolsExtensionSpec.php
+++ b/spec/LdapTools/Bundle/LdapToolsBundle/DependencyInjection/LdapToolsExtensionSpec.php
@@ -148,7 +148,7 @@ class LdapToolsExtensionSpec extends ObjectBehavior
             "default_target_path" => "/",
             "always_use_target_path" => false,
             "target_path_parameter" => "_target_path",
-            "use_referrer" => false,
+            "use_referer" => false,
             "login_path" => '/login',
         ])->shouldBeCalled();
         $container->setParameter("ldap_tools.security.guard.auth_failure", [


### PR DESCRIPTION
For historical reasons, and to match the misspelling of the HTTP standard, the option is called use_referer instead of use_referrer.

See: https://symfony.com/doc/current/reference/configuration/security.html#use-referer