### PR TITLE
Issue #57 bugfix

### DIFF
--- a/Doctrine/Subscriber/LdapObjectSubscriber.php
+++ b/Doctrine/Subscriber/LdapObjectSubscriber.php
@@ -255,7 +255,7 @@ class LdapObjectSubscriber implements EventSubscriber
      */
     protected function getObjectFromLifeCycleArgs(LifecycleEventArgs $args)
     {
-        $rc = new \ReflectionClass('Doctrine\Common\Persistence\Event\LifecycleEventArgs');
+        $rc = new \ReflectionClass('Doctrine\ORM\Event\LifecycleEventArgs');
 
         if ($rc->hasMethod('getObject')) {
             return $args->getObject();
@@ -272,7 +272,7 @@ class LdapObjectSubscriber implements EventSubscriber
      */
     protected function getOmFromLifeCycleArgs(LifecycleEventArgs $args)
     {
-        $rc = new \ReflectionClass('Doctrine\Common\Persistence\Event\LifecycleEventArgs');
+        $rc = new \ReflectionClass('Doctrine\ORM\Event\LifecycleEventArgs');
 
         if ($rc->hasMethod('getObjectManager')) {
             return $args->getObjectManager();

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "ldaptools/ldaptools-bundle",
+    "name": "nuxnik/ldaptools-bundle",
     "type": "symfony-bundle",
     "description": "Provides easy LDAP integration for Symfony via LdapTools.",
     "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -37,5 +37,11 @@
     },
     "autoload": {
         "psr-4": {"LdapTools\\Bundle\\LdapToolsBundle\\": ""}
-    }
+    },
+    "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/nuxnik/ldaptools-bundle.git"
+        }
+    ]
 }

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "ldaptools/ldaptools": ">=0.25",
+        "ldaptools/ldaptools": "dev-feature/PB-18645-php8",
         "symfony/framework-bundle": "~2.7|~3.0|~4.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     "repositories": [
         {
             "type": "git",
-            "url": "https://github.com/nuxnik/ldaptools-bundle.git"
+            "url": "https://github.com/passbolt/ldaptools.git"
         }
     ]
 }


### PR DESCRIPTION
The following class: Doctrine\Common\Persistence\Event\LifecycleEventArgs is not available in ldaptools because it in not available in the composer.json and therefore results in reflection exception:

> Class Doctrine\Common\Persistence\Event\LifecycleEventArgs does not exist

This has been renamed to available class "Doctrine\ORM\Event\LifecycleEventArgs" from the "doctrine/orm" bundle. 